### PR TITLE
Only include a new/failed AnP/ID bridge for "In Progress" AnPs.

### DIFF
--- a/lib/Genome/Model/Tools/ApipeMetricsDaemon.pm
+++ b/lib/Genome/Model/Tools/ApipeMetricsDaemon.pm
@@ -465,8 +465,8 @@ sub lims_apipe_bridge {
 
     my $select = q(SELECT COUNT(DISTINCT(d.instrument_data_id)) FROM config.instrument_data_analysis_project_bridge AS d JOIN config.analysis_project AS p ON (d.analysis_project_id = p.id));
     my @cases = (
-        ['new', q(WHERE d.status = 'new' AND p.status NOT IN ('Hold', 'Pending'))],
-        ['failed', q(WHERE d.status = 'failed' AND p.status NOT IN ('Hold', 'Pending'))],
+        ['new', q(WHERE d.status = 'new' AND p.status = 'In Progress')],
+        ['failed', q(WHERE d.status = 'failed' AND p.status = 'In Progress')],
         ['hold', q(WHERE d.status in ('new', 'failed') AND p.status = 'Hold')],
         ['pending', q(WHERE d.status in ('new', 'failed') AND p.status = 'Pending')],
     );


### PR DESCRIPTION
As our number of statuses proliferate, we still really only care about `new` and `failed` bridges for projects we are interested in processing.
